### PR TITLE
Devices API support

### DIFF
--- a/src/xivelyjs.js
+++ b/src/xivelyjs.js
@@ -440,6 +440,76 @@
         });
       }
     };
+    
+    
+    
+    // ---------------------------------
+    // Devices module
+    //
+    this.devices = {
+      list: function(productid, options, callback) {
+        request({
+          url     : apiEndpoint +"/products/"+ productid +"/devices",
+          data    : options,
+          always  : callback
+        });
+      },
+      
+      activate: function(activationcode, callback) {
+          request({
+            url     : apiEndpoint +"/devices/"+ activationcode +"/activate",
+            always  : callback
+          });
+        },
+
+      create: function(productid, data, callback) {
+        request({
+          type    : "post",
+          url     : apiEndpoint +"/products/" + productid + "/devices",
+          data    : data,
+          always  : callback
+        });
+      },
+      
+      read: function(productid, deviceserial, callback) {
+
+          request({
+            url     : apiEndpoint +"/products/"+ productid +"/devices/" + deviceserial,
+            always  : callback
+          });
+      },
+
+      update: function(productid, deviceserial, data, callback) {
+
+          request({
+        	type	: "put",
+            url     : apiEndpoint +"/products/"+ productid +"/devices/" + deviceserial,
+            data	: data,
+            always  : callback
+          });
+      },
+      'delete': function(productid, deviceserial, callback) {
+
+          request({
+        	type	: "delete",
+            url     : apiEndpoint +"/products/"+ productid +"/devices/" + deviceserial,
+            always  : callback
+          });
+      }
+
+
+    };
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
 
     this._settings = function() {
       return {

--- a/src/xivelyjs.js
+++ b/src/xivelyjs.js
@@ -482,7 +482,7 @@
       update: function(productid, deviceserial, data, callback) {
 
           request({
-        	type	: "put",
+            type    : "put",
             url     : apiEndpoint +"/products/"+ productid +"/devices/" + deviceserial,
             data	: data,
             always  : callback
@@ -491,7 +491,7 @@
       'delete': function(productid, deviceserial, callback) {
 
           request({
-        	type	: "delete",
+            type    : "delete",
             url     : apiEndpoint +"/products/"+ productid +"/devices/" + deviceserial,
             always  : callback
           });

--- a/xivelyjs-1.0.4.js
+++ b/xivelyjs-1.0.4.js
@@ -363,6 +363,54 @@
                 });
             }
         };
+        // ---------------------------------
+        // Devices module
+        //
+        this.devices = {
+          list: function(productid, options, callback) {
+            request({
+              url     : apiEndpoint +"/products/"+ productid +"/devices",
+              data    : options,
+              always  : callback
+            });
+          },
+          activate: function(activationcode, callback) {
+              request({
+                url     : apiEndpoint +"/devices/"+ activationcode +"/activate",
+                always  : callback
+              });
+            },
+          create: function(productid, data, callback) {
+            request({
+              type    : "post",
+              url     : apiEndpoint +"/products/" + productid + "/devices",
+              data    : data,
+              always  : callback
+            });
+          },
+          read: function(productid, deviceserial, callback) {
+              request({
+                url     : apiEndpoint +"/products/"+ productid +"/devices/" + deviceserial,
+                always  : callback
+              });
+          },
+          update: function(productid, deviceserial, data, callback) {
+              request({
+            	type	: "put",
+                url     : apiEndpoint +"/products/"+ productid +"/devices/" + deviceserial,
+                data	: data,
+                always  : callback
+              });
+          },
+          'delete': function(productid, deviceserial, callback) {
+
+              request({
+            	type	: "delete",
+                url     : apiEndpoint +"/products/"+ productid +"/devices/" + deviceserial,
+                always  : callback
+              });
+          }
+        };
         this._settings = function() {
             return {
                 apiKey: apiKey,


### PR DESCRIPTION
Added support for an xively.devices module, which adds CRUD as well as list() and activate() support for devices, according to the Devices API (https://personal.xively.com/dev/docs/api/product_management/devices/).
